### PR TITLE
Only index INSPIRE keywords when they have the right thesaurus

### DIFF
--- a/src/main/plugin/iso19139.nl.geografie.1.3.1/index-fields/default.xsl
+++ b/src/main/plugin/iso19139.nl.geografie.1.3.1/index-fields/default.xsl
@@ -304,6 +304,8 @@
         <xsl:variable name="listOfKeywords"
                       select="gmd:keyword/gco:CharacterString|
                                         gmd:keyword/gmx:Anchor"/>
+        <xsl:variable name="thesaurusName" select="gmd:thesaurusName/gmd:CI_Citation/gmd:title/*[1]"/>
+
         <xsl:for-each select="$listOfKeywords">
           <xsl:variable name="keyword" select="string(.)"/>
 
@@ -325,7 +327,7 @@
 
           <!-- If INSPIRE is enabled, check if the keyword is one of the 34 themes
                and index annex, theme and theme in english. -->
-          <xsl:if test="$inspire='true'">
+          <xsl:if test="$inspire='true' and normalize-space(lower-case($thesaurusName)) = 'gemet - inspire themes, version 1.0'">
             <xsl:if test="string-length(.) &gt; 0">
 
               <xsl:variable name="inspireannex">


### PR DESCRIPTION
Checks the existence of a thesaurus with title `GEMET - Inspire themes, version 1.0` to extract the INSPIRE related fields.