### PR TITLE
DCAT-AP NL 3 formatter

### DIFF
--- a/src/main/plugin/iso19139.nl.geografie.1.3.1/formatter/dcat-ap-nl-3-html/config.properties
+++ b/src/main/plugin/iso19139.nl.geografie.1.3.1/formatter/dcat-ap-nl-3-html/config.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2001-2016 Food and Agriculture Organization of the
+# United Nations (FAO-UN), United Nations World Food Programme (WFP)
+# and United Nations Environment Programme (UNEP)
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or (at
+# your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+#
+# Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+# Rome - Italy. email: geonetwork@osgeo.org
+#
+
+published=false

--- a/src/main/plugin/iso19139.nl.geografie.1.3.1/formatter/dcat-ap-nl-3-html/view.xsl
+++ b/src/main/plugin/iso19139.nl.geografie.1.3.1/formatter/dcat-ap-nl-3-html/view.xsl
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:gts="http://www.isotc211.org/2005/gts"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:gml320="http://www.opengis.net/gml"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:srv="http://www.isotc211.org/2005/srv"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                xmlns:tr="java:org.fao.geonet.api.records.formatters.SchemaLocalizations"
+                xmlns:gn-fn-render="http://geonetwork-opensource.org/xsl/functions/render"
+                xmlns:gn-fn-metadata="http://geonetwork-opensource.org/xsl/functions/metadata"
+                xmlns:gn-fn-iso19139="http://geonetwork-opensource.org/xsl/functions/profiles/iso19139"
+                xmlns:xslUtils="java:org.fao.geonet.util.XslUtil"
+                xmlns:saxon="http://saxon.sf.net/"
+                version="2.0"
+                extension-element-prefixes="saxon"
+                exclude-result-prefixes="#all">
+
+  <xsl:import href="../../../iso19139.nl.geografie.2.0.0/formatter/xsl-view/view.xsl"/>
+
+</xsl:stylesheet>

--- a/src/main/plugin/iso19139.nl.geografie.1.3.1/formatter/dcat-ap-nl-3/view.xsl
+++ b/src/main/plugin/iso19139.nl.geografie.1.3.1/formatter/dcat-ap-nl-3/view.xsl
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                version="2.0"
+                exclude-result-prefixes="#all">
+
+  <xsl:import href="../../../iso19139.nl.geografie.2.0.0/formatter/dcat-ap-nl-3/view.xsl"/>
+</xsl:stylesheet>

--- a/src/main/plugin/iso19139.nl.geografie.1.3.1/schematron/schematron-rules-dcat-ap-nl-3.sch
+++ b/src/main/plugin/iso19139.nl.geografie.1.3.1/schematron/schematron-rules-dcat-ap-nl-3.sch
@@ -1,0 +1,316 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+            xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+            xmlns:geonet="http://www.fao.org/geonetwork"
+            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            queryBinding="xslt2">
+  <sch:title xmlns="http://www.w3.org/2001/XMLSchema">DCAT-AP NL 3 </sch:title>
+
+  <sch:ns uri="http://www.isotc211.org/2005/gmd" prefix="gmd"/>
+  <sch:ns uri="http://www.isotc211.org/2005/gco" prefix="gco"/>
+  <sch:ns uri="http://www.isotc211.org/2005/gmx" prefix="gmx"/>
+  <sch:ns uri="http://www.opengis.net/gml" prefix="gml"/>
+  <sch:ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <sch:ns uri="http://www.w3.org/2001/XMLSchema-instance" prefix="xsi"/>
+  <sch:ns uri="http://www.w3.org/2004/02/skos/core#" prefix="skos"/>
+  <sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
+  <sch:ns prefix="xsl" uri="http://www.w3.org/1999/XSL/Transform"/>
+  <sch:ns prefix="rdf" uri="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <sch:ns prefix="xslutil" uri="java:org.fao.geonet.util.XslUtil" />
+
+  <sch:let name="lowercase" value="'abcdefghijklmnopqrstuvwxyz'"/>
+  <sch:let name="uppercase" value="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+
+
+  <!-- Function to check that the metadata has a topic category that can be mapped to EuDcatApThemes -->
+  <xsl:function name="geonet:hasEuDcatApThemes" as="xs:boolean">
+    <xsl:param name="values"  as="node()*" />
+
+    <!--<xsl:message>$values: <xsl:value-of select="$values" /></xsl:message>-->
+    <xsl:variable name="isoTopicToEuDcatApThemes"
+                  as="node()*">
+      <entry key="http://publications.europa.eu/resource/authority/data-theme/AGRI">
+        <inspire>http://inspire.ec.europa.eu/theme/af</inspire>
+        <iso>farming</iso>
+      </entry>
+      <entry key="http://publications.europa.eu/resource/authority/data-theme/ECON">
+        <inspire>http://inspire.ec.europa.eu/theme/cp</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/lu</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/mr</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/pf</inspire>
+        <iso>economy</iso>
+        <iso>planningCadastre</iso>
+      </entry>
+      <entry key="http://publications.europa.eu/resource/authority/data-theme/EDUC"></entry>
+      <entry key="http://publications.europa.eu/resource/authority/data-theme/ENER">
+        <inspire>http://inspire.ec.europa.eu/theme/er</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/mr</inspire>
+      </entry>
+      <entry key="http://publications.europa.eu/resource/authority/data-theme/ENVI">
+        <inspire>http://inspire.ec.europa.eu/theme/hy</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/ps</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/lc</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/am</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/ac</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/br</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/ef</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/hb</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/lu</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/mr</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/nz</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/of</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/sr</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/so</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/sd</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/mf</inspire>
+        <iso>biota</iso>
+        <iso>environment</iso>
+        <iso>inlandWaters</iso>
+        <iso>oceans</iso>
+        <iso>climatologyMeteorologyAtmosphere</iso>
+      </entry>
+      <entry key="http://publications.europa.eu/resource/authority/data-theme/GOVE">
+        <inspire>http://inspire.ec.europa.eu/theme/au</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/us</inspire>
+      </entry>
+      <entry key="http://publications.europa.eu/resource/authority/data-theme/HEAL">
+        <inspire>http://inspire.ec.europa.eu/theme/hh</inspire>
+        <iso>health</iso>
+      </entry>
+      <entry key="http://publications.europa.eu/resource/authority/data-theme/INTR"></entry>
+      <entry key="http://publications.europa.eu/resource/authority/data-theme/JUST"></entry>
+      <entry key="http://publications.europa.eu/resource/authority/data-theme/OP_DATPRO"></entry>
+      <entry key="http://publications.europa.eu/resource/authority/data-theme/REGI">
+        <inspire>http://inspire.ec.europa.eu/theme/ad</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/rs</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/gg</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/cp</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/gn</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/el</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/ge</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/oi</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/bu</inspire>
+        <iso>planningCadastre</iso>
+        <iso>boundaries</iso>
+        <iso>elevation</iso>
+        <iso>imageryBaseMapsEarthCover</iso>
+      </entry>
+      <entry key="http://publications.europa.eu/resource/authority/data-theme/SOCI">
+        <inspire>http://inspire.ec.europa.eu/theme/pd</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/su</inspire>
+        <iso>location</iso>
+        <iso>society</iso>
+        <iso>disaster</iso>
+        <iso>intelligenceMilitary</iso>
+        <iso>extraTerrestrial</iso>
+      </entry>
+      <entry key="http://publications.europa.eu/resource/authority/data-theme/TECH">
+        <inspire>http://inspire.ec.europa.eu/theme/hy</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/ge</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/oi</inspire>
+        <inspire>http://inspire.ec.europa.eu/theme/mf</inspire>
+        <iso>geoscientificInformation</iso>
+      </entry>
+      <entry key="http://publications.europa.eu/resource/authority/data-theme/TRAN">
+        <inspire>http://inspire.ec.europa.eu/theme/tn</inspire>
+        <iso>structure</iso>
+        <iso>transportation</iso>
+        <iso>utilitiesCommunication</iso>
+      </entry>
+    </xsl:variable>
+
+    <xsl:variable name="theme"
+      select="$isoTopicToEuDcatApThemes[
+      */text() = $values/*/text()
+      or */text() = $values/*/@xlink:href]/@key"/>
+
+    <!--<xsl:message>$theme: <xsl:value-of select="$theme" /></xsl:message>-->
+    <xsl:value-of select="$theme != ''" />
+  </xsl:function>
+
+
+  <!-- Function to check that the license is a valid one for DCAT-AP NL -->
+  <xsl:function name="geonet:isValidLicense" as="xs:boolean">
+    <xsl:param name="resourceConstraints"  as="node()*" />
+
+    <!--<xsl:message><xsl:copy-of select="$resourceConstraints/*/gmd:useLimitation" /></xsl:message>-->
+
+    <xsl:variable name="euLicenses"
+                  select="document('../../iso19139.nl.geografie.2.0.0/formatter/dcat-ap-nl-3/vocabularies/licences-skos.rdf')"/>
+
+    <xsl:variable name="licenses">
+      <xsl:for-each select="$resourceConstraints/*/gmd:otherConstraints">
+
+        <xsl:variable name="httpUriInAnchorOrText"
+          select="(gmx:Anchor/@xlink:href[starts-with(., 'http')]
+          |gco:CharacterString[starts-with(., 'http')])[1]"/>
+
+
+        <xsl:if test="$httpUriInAnchorOrText != ''">
+          <xsl:variable name="licenseUriWithoutHttp"
+            select="replace($httpUriInAnchorOrText,'https?://','')"/>
+
+          <xsl:variable name="euDcatLicense"
+            select="$euLicenses/rdf:RDF/skos:Concept[
+            matches(skos:exactMatch/@rdf:resource,
+            concat('https?://', $licenseUriWithoutHttp, '/?'))
+            or matches(@rdf:about,
+            concat('https?://', $licenseUriWithoutHttp, '/?'))]"/>
+
+          <xsl:if test="string($euDcatLicense)"><xsl:value-of select="$euDcatLicense" /></xsl:if>
+        </xsl:if>
+
+
+      </xsl:for-each>
+
+    </xsl:variable>
+
+    <xsl:value-of select="normalize-space($licenses) != ''" />
+  </xsl:function>
+
+
+  <!-- Function to check that the rights are a valid one for DCAT-AP NL -->
+  <xsl:function name="geonet:isValidRights" as="xs:boolean">
+    <xsl:param name="resourceConstraints"  as="node()*" />
+
+    <xsl:variable name="dcatApAccessTypes" as="node()*">
+      <entry key="http://publications.europa.eu/resource/authority/access-right/PUBLIC">unrestricted</entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/PUBLIC">licenceUnrestricted</entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/RESTRICTED">restricted</entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/NON_PUBLIC">private</entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/CONFIDENTIAL">confidential</entry>
+
+      <!-- TODO: review with dct:rights -->
+      <!--<entry key="http://publications.europa.eu/resource/authority/access-right/PUBLIC">http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations</entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/NON_PUBLIC">https://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/INSPIRE_Directive_Article13_1e</entry>-->
+
+      <!-- Dutch specific -->
+      <entry key="http://publications.europa.eu/resource/authority/access-right/PUBLIC">Geen beperkingen</entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/PUBLIC" match="start">Naamsvermelding verplicht,</entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/PUBLIC">http://creativecommons.org/publicdomain/mark/1.0/deed.nl</entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/PUBLIC">http://creativecommons.org/publicdomain/zero/1.0/deed.nl</entry>
+
+      <entry key="http://publications.europa.eu/resource/authority/access-right/PUBLIC">http://creativecommons.org/licenses/by/3.0/deed.nl</entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/PUBLIC">http://creativecommons.org/licenses/by/4.0/deed.nl</entry>
+
+      <entry key="http://publications.europa.eu/resource/authority/access-right/RESTRICTED" match="start">Gelijk Delen, Naamsvermelding verplicht,</entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/RESTRICTED">http://creativecommons.org/licenses/by-sa/3.0/deed.nl</entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/RESTRICTED">http://creativecommons.org/licenses/by-sa/4.0/deed.nl</entry>
+
+      <entry key="http://publications.europa.eu/resource/authority/access-right/RESTRICTED" match="start">Niet Commercieel, Naamsvermelding verplicht </entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/RESTRICTED">http://creativecommons.org/licenses/by-nc/3.0/deed.nl</entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/RESTRICTED">http://creativecommons.org/licenses/by-nc/4.0/deed.nl</entry>
+
+      <entry key="http://publications.europa.eu/resource/authority/access-right/RESTRICTED" match="start">Niet Commercieel, Gelijk Delen, Naamsvermelding verplicht,</entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/RESTRICTED">http://creativecommons.org/licenses/by-nc-sa/3.0/deed.nl</entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/RESTRICTED">http://creativecommons.org/licenses/by-nc-sa/4.0/deed.nl</entry>
+
+      <entry key="http://publications.europa.eu/resource/authority/access-right/RESTRICTED" match="start">Geen Afgeleide Werken, Naamsvermelding verplicht,</entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/RESTRICTED">http://creativecommons.org/licenses/by-nd/3.0/deed.nl</entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/RESTRICTED">http://creativecommons.org/licenses/by-nd/4.0/deed.nl</entry>
+
+      <entry key="http://publications.europa.eu/resource/authority/access-right/RESTRICTED" match="start">Niet Commercieel, Geen Afgeleide Werken, Naamsvermelding verplicht,</entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/RESTRICTED">http://creativecommons.org/licenses/by-nc-nd/3.0/deed.nl</entry>
+      <entry key="http://publications.europa.eu/resource/authority/access-right/RESTRICTED">http://creativecommons.org/licenses/by-nc-nd/4.0/deed.nl</entry>
+
+      <!-- TODO: review other allowed values related to this license -->
+      <entry key="http://publications.europa.eu/resource/authority/access-right/RESTRICTED">Geo Gedeeld licentie</entry>
+    </xsl:variable>
+
+
+    <xsl:variable name="rightsStatements">
+
+      <xsl:for-each select="distinct-values($resourceConstraints/*[gmd:accessConstraints]/gmd:otherConstraints/(gco:CharacterString|gmx:Anchor))">
+        <xsl:variable name="dcatAccessType"
+                      select="$dcatApAccessTypes[(lower-case(.) = lower-case(current()) and not(@match)) or
+                                                   (starts-with(lower-case(current()), lower-case(.)) and (@match = 'start'))] "/>
+
+        <xsl:if test="$dcatAccessType">
+          <right key="{$dcatAccessType/@key}" />
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <xsl:value-of select="count($rightsStatements/right) > 0" />
+  </xsl:function>
+
+  <sch:pattern>
+    <sch:title>Validatie tegen het DCAT-AP NL 3.0 metadata profiel</sch:title>
+
+    <!-- Dataset title -->
+    <sch:rule context="//gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:title">
+      <sch:let name="mdTitle" value="gco:CharacterString"/>
+      <sch:assert test="$mdTitle != ''">Titel van de bron ontbreekt</sch:assert>
+    </sch:rule>
+
+    <!-- Dataset abstract -->
+    <sch:rule context="//gmd:MD_Metadata/gmd:identificationInfo/*/gmd:abstract">
+      <sch:let name="mdAbstract" value="gco:CharacterString"/>
+      <sch:assert test="$mdAbstract != ''">Samenvatting ontbreekt</sch:assert>
+    </sch:rule>
+
+    <!-- Dataset language -->
+    <sch:rule context="//gmd:MD_Metadata/gmd:identificationInfo/*/gmd:language">
+      <sch:let name="mdLanguage" value="(*/@codeListValue = 'dut' or */@codeListValue = 'eng')"/>
+
+      <sch:assert test="$mdLanguage">De taal van de bron moet Nederlands of Engels zijn</sch:assert>
+    </sch:rule>
+
+    <!-- Dataset identifier -->
+    <sch:rule context="//gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:identifier/*/gmd:code">
+      <sch:let name="mdIdentifier" value="./(gco:CharacterString|gmx:Anchor)/text()"/>
+
+      <sch:assert test="$mdIdentifier != ''">Unieke Identifier van de bron ontbreekt</sch:assert>
+    </sch:rule>
+
+    <!-- Dataset contact -->
+    <sch:rule context="//gmd:MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact[1]/gmd:CI_ResponsibleParty/gmd:organisationName">
+      <sch:let name="orgName" value="./(gco:CharacterString|gmx:Anchor)/text()"/>
+
+      <sch:assert test="$orgName != ''">Verantwoordelijke organisatie bron ontbreekt</sch:assert>
+    </sch:rule>
+
+    <sch:rule context="//gmd:MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact[1]/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+      <sch:let name="email" value="gco:CharacterString"/>
+
+      <sch:let name="isValidEmail" value="xslutil:isValidEmail($email)" />
+
+      <sch:assert test="$isValidEmail = true()">Verantwoordelijke organisatie bron e-mail ontbreekt of is ongeldig</sch:assert>
+    </sch:rule>
+
+    <!-- Dataset thema -->
+    <sch:rule context="//gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification">
+      <sch:assert test="geonet:hasEuDcatApThemes(gmd:topicCategory)">Dataset category: a topic category or a INSPIRE Theme keyword is required</sch:assert>
+
+      <sch:assert test="geonet:isValidLicense(gmd:resourceConstraints)">Een geldige Creative Commons-licentie voor Overige beperkingen / (Juridische) toegangs restricties is vereist. Zie https://definities.geostandaarden.nl/dcat-ap-nl/nl/</sch:assert>
+
+      <sch:assert test="geonet:isValidRights(gmd:resourceConstraints)">Een geldige Creative Commons-licentie voor Overige beperkingen / (Juridische) gebruiksbeperking is vereist. Zie https://definities.geostandaarden.nl/dcat-ap-nl/nl/</sch:assert>
+    </sch:rule>
+
+    <sch:rule context="//gmd:MD_Metadata/gmd:identificationInfo/*/gmd:status">
+      <sch:let name="status" value="*/@codeListValue"/>
+
+      <sch:assert test="$status != ''">Status ontbreekt</sch:assert>
+    </sch:rule>
+
+    <sch:rule context="//gmd:MD_Metadata/gmd:identificationInfo/*/gmd:resourceMaintenance/gmd:MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency">
+      <sch:let name="frequency" value="*/@codeListValue"/>
+
+      <sch:assert test="$frequency != ''">Herzieningsfrequentie ontbreekt</sch:assert>
+    </sch:rule>
+
+    <!-- Distribution -->
+    <sch:rule context="//gmd:MD_Metadata/gmd:distributionInfo/*/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:linkage">
+      <sch:let name="distributionLink" value="gmd:URL"/>
+
+      <sch:assert test="$distributionLink != ''">Databronnen linkage ontbreekt</sch:assert>
+    </sch:rule>
+
+    <sch:rule context="//gmd:MD_Metadata/gmd:distributionInfo/*/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:protocol">
+      <sch:let name="distributionProtocol" value="./(gco:CharacterString|gmx:Anchor)/text()"/>
+
+      <sch:assert test="$distributionProtocol != ''">Databronnen protocol ontbreekt</sch:assert>
+    </sch:rule>
+  </sch:pattern>
+
+</sch:schema>

--- a/src/main/resources/config-spring-geonetwork.xml
+++ b/src/main/resources/config-spring-geonetwork.xml
@@ -7,6 +7,14 @@
 
   <bean id="iso19139.nl.geografie.1.3.1SchemaPlugin"
         class="org.fao.geonet.schema.iso19139.ISO19139SchemaPlugin">
+      <property name="outputSchemas">
+          <util:map key-type="java.lang.String" value-type="java.lang.String">
+              <entry key="csw" value="http://www.opengis.net/cat/csw/2.0.2"/>
+              <entry key="mdb" value="http://standards.iso.org/iso/19115/-3/mdb/2.0"/>
+              <entry key="gmd" value="http://www.isotc211.org/2005/gmd"/>
+              <entry key="dcat-ap-nl-3" value="https://docs.geostandaarden.nl/dcat/dcat-ap-nl30"/>
+          </util:map>
+      </property>
       <property name="xpathTitle">
           <util:list value-type="java.lang.String">
               <value>gmd:identificationInfo/*/gmd:citation/*/gmd:title/gco:CharacterString</value>


### PR DESCRIPTION
- Add export from Dutch ISO profiles to DCAT-AP NL 3 profile (RDF/XML)
- Metadata HTML view to display the DCAT-AP NL 3 profile information mapped from the Dutch ISO profiles
- Validation rules for ISO properties mapped to mandatory DCAT-AP NL 3 profile

--- 

Depends on https://github.com/metadata101/iso19139.nl.geografie.2.0.0

Requires https://github.com/metadata101/iso19139.nl.geografie.2.0.0/pull/18